### PR TITLE
Fix syntax highlighting in github

### DIFF
--- a/homebridge/generate_service.sh
+++ b/homebridge/generate_service.sh
@@ -11,7 +11,7 @@ function create_service_file {
   local setup_id=$5
 
      # Write the service configurtion file to the current directory
-cat <<EOF>"${name}.service"
+cat <<EOF > "${name}.service"
 <service-group>
   <name>$name</name>
   <service>


### PR DESCRIPTION
The syntax highlighting in github was broken. These spaces are fixing it 🙂 
btw: Thank you for your script! I've forked it for use with kubernetes: https://gist.github.com/maxnowack/e6d36caf7f8258f0202805c158fed079